### PR TITLE
Scaffold: Astro site + 3 Streamlit apps

### DIFF
--- a/apps/dashboard02/app.py
+++ b/apps/dashboard02/app.py
@@ -1,0 +1,14 @@
+import streamlit as st
+import pandas as pd
+
+st.title("Dashboard 02")
+
+uploaded = st.file_uploader("Upload CSV", type="csv")
+if uploaded:
+    df = pd.read_csv(uploaded)
+    st.dataframe(df)
+    numeric_cols = df.select_dtypes("number")
+    if not numeric_cols.empty:
+        st.line_chart(numeric_cols)
+else:
+    st.write("Upload a CSV file to visualize.")

--- a/apps/dashboard02/requirements.txt
+++ b/apps/dashboard02/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+pandas

--- a/apps/franchise-inspector/app.py
+++ b/apps/franchise-inspector/app.py
@@ -1,0 +1,15 @@
+import streamlit as st
+import pandas as pd
+from io import StringIO
+
+st.title("Franchise Inspector")
+
+data = st.text_area("Paste CSV data", height=200)
+if data:
+    df = pd.read_csv(StringIO(data))
+    st.write("Preview")
+    st.dataframe(df.head())
+    st.write("Summary")
+    st.write(df.describe())
+else:
+    st.write("Paste CSV data to inspect.")

--- a/apps/franchise-inspector/requirements.txt
+++ b/apps/franchise-inspector/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+pandas

--- a/apps/proposal-summarizer/app.py
+++ b/apps/proposal-summarizer/app.py
@@ -1,0 +1,18 @@
+import streamlit as st
+import pandas as pd
+from pypdf import PdfReader
+
+st.title("Proposal Summarizer")
+
+uploaded = st.file_uploader("Upload PDF", type="pdf")
+if uploaded:
+    reader = PdfReader(uploaded)
+    text = ""
+    for page in reader.pages:
+        text += page.extract_text() + "\n"
+    st.subheader("Extracted Text")
+    st.write(text[:1000])
+    st.subheader("Word Count")
+    st.write(len(text.split()))
+else:
+    st.write("Upload a PDF to summarize.")

--- a/apps/proposal-summarizer/requirements.txt
+++ b/apps/proposal-summarizer/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+pandas
+pypdf

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,22 @@
+[build]
+  base = "site"
+  command = "npm run build"
+  publish = "dist"
+
+[[redirects]]
+  from = "/apps/dashboard02"
+  to = "https://dashboard02.streamlit.app/"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/apps/franchise-inspector"
+  to = "https://inspector.streamlit.app/"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/apps/proposal-summarizer"
+  to = "https://summarizer.streamlit.app/"
+  status = 200
+  force = true

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config';
+import tailwind from '@astrojs/tailwind';
+
+export default defineConfig({
+  integrations: [tailwind()],
+});

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "site",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^4.0.0",
+    "@astrojs/tailwind": "^5.0.0",
+    "tailwindcss": "^3.3.0"
+  }
+}

--- a/site/postcss.config.cjs
+++ b/site/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -1,0 +1,18 @@
+---
+export interface Props {
+  title: string;
+}
+const { title } = Astro.props;
+import '../styles/global.css';
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>{title}</title>
+  </head>
+  <body class="prose mx-auto p-4">
+    <slot />
+  </body>
+</html>

--- a/site/src/pages/articles/index.astro
+++ b/site/src/pages/articles/index.astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../../layouts/Layout.astro';
+---
+<Layout title="Articles">
+  <h1>Articles</h1>
+  <p>Blog posts coming soon.</p>
+</Layout>

--- a/site/src/pages/contact.astro
+++ b/site/src/pages/contact.astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+<Layout title="Contact">
+  <h1>Contact</h1>
+  <p>Email us at example@example.com.</p>
+</Layout>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,0 +1,6 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+<Layout title="Home">
+  <h1>Welcome to Sidiqi App</h1>
+</Layout>

--- a/site/src/pages/labs.astro
+++ b/site/src/pages/labs.astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+<Layout title="Labs">
+  <h1>Labs</h1>
+  <p>Experimental projects.</p>
+</Layout>

--- a/site/src/pages/services.astro
+++ b/site/src/pages/services.astro
@@ -1,0 +1,7 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+<Layout title="Services">
+  <h1>Services</h1>
+  <p>We offer a range of services.</p>
+</Layout>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/site/tailwind.config.cjs
+++ b/site/tailwind.config.cjs
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{astro,html,js,jsx,ts,tsx,md,mdx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/strict"
+}


### PR DESCRIPTION
## Summary
- scaffolded Astro site with Tailwind and starter pages
- added three Streamlit apps: dashboard02, franchise inspector, and proposal summarizer
- configured Netlify for build and proxying to Streamlit apps

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@astrojs%2ftailwind)*
- `npm run build` *(fails: astro: not found)*
- `python apps/dashboard02/app.py` *(fails: ModuleNotFoundError: No module named 'streamlit')*


------
https://chatgpt.com/codex/tasks/task_e_689bf40b5c1483318823f70217d3f5ef